### PR TITLE
Renamed STM32Pager to RFM69

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -36,13 +36,13 @@ impl Default for RaspagerConfig {
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
-pub struct STM32PagerConfig {
+pub struct RFM69Config {
     pub port: String
 }
 
-impl Default for STM32PagerConfig {
-    fn default() -> STM32PagerConfig {
-        STM32PagerConfig {
+impl Default for RFM69Config {
+    fn default() -> RFM69Config {
+        RFM69Config {
             port: String::from("/dev/ttyUSB0")
         }
     }
@@ -122,7 +122,7 @@ pub enum Transmitter {
     Audio,
     C9000,
     Raspager,
-    STM32Pager
+    RFM69 
 }
 
 impl Default for Transmitter {
@@ -138,7 +138,7 @@ impl fmt::Display for Transmitter {
             Transmitter::Audio => "Audio",
             Transmitter::C9000 => "C9000",
             Transmitter::Raspager => "RaspagerV1",
-            Transmitter::STM32Pager => "STM32Pager"
+            Transmitter::RFM69 => "RFM69"
         };
         write!(f, "{}", name)
     }
@@ -157,7 +157,7 @@ pub struct Config {
     #[serde(default)]
     pub audio: AudioConfig,
     #[serde(default)]
-    pub stm32pager: STM32PagerConfig,
+    pub rfm69: RFM69Config,
 }
 
 impl Config {

--- a/src/frontend/assets/index.html
+++ b/src/frontend/assets/index.html
@@ -21,7 +21,7 @@
                 <option>Audio</option>
                 <option value="Raspager">Raspager V1</option>
                 <option>C9000</option>
-                <option>STM32Pager</option>
+                <option>RFM69</option>
               </select>
             </div>
             <div class="form-row">
@@ -81,16 +81,16 @@
           </div>
         </div>
 
-        <div class="box" v-if="config.transmitter == 'STM32Pager'">
+        <div class="box" v-if="config.transmitter == 'RFM69'">
           <div class="box-header">
-            <h3>STM32Pager Config</h3>
+            <h3>RFM69 Config</h3>
           </div>
           <div class="box-content">
             <div class="form-row">
               <div class="form-group">
-                <label for="stm32pager-port">Serial Port</label>
-                <input type="text" id="stm32pager-port"
-                       v-model="config.stm32pager.port">
+                <label for="rfm69-port">Serial Port</label>
+                <input type="text" id="rfm69-port"
+                       v-model="config.rfm69.port">
               </div>
             </div>
           </div>

--- a/src/pocsag/scheduler.rs
+++ b/src/pocsag/scheduler.rs
@@ -58,8 +58,8 @@ impl Scheduler {
                     scheduler.run(RaspagerTransmitter::new(&config)),
                 Transmitter::C9000 =>
                     scheduler.run(C9000Transmitter::new(&config)),
-                Transmitter::STM32Pager =>
-                    scheduler.run(STM32Transmitter::new(&config))
+                Transmitter::RFM69 =>
+                    scheduler.run(RFM69Transmitter::new(&config))
             };
         })
     }

--- a/src/transmitter/mod.rs
+++ b/src/transmitter/mod.rs
@@ -2,7 +2,7 @@ pub mod ptt;
 pub mod dummy;
 pub mod audio;
 pub mod c9000;
-pub mod stm32pager;
+pub mod rfm69;
 pub mod raspager;
 
 pub use self::ptt::Ptt;
@@ -10,7 +10,7 @@ pub use self::dummy::DummyTransmitter;
 pub use self::audio::AudioTransmitter;
 pub use self::c9000::C9000Transmitter;
 pub use self::raspager::RaspagerTransmitter;
-pub use self::stm32pager::STM32Transmitter;
+pub use self::rfm69::RFM69Transmitter;
 
 use pocsag::Generator;
 

--- a/src/transmitter/rfm69/mod.rs
+++ b/src/transmitter/rfm69/mod.rs
@@ -1,0 +1,3 @@
+mod transmitter;
+
+pub use self::transmitter::RFM69Transmitter;

--- a/src/transmitter/rfm69/transmitter.rs
+++ b/src/transmitter/rfm69/transmitter.rs
@@ -4,15 +4,15 @@ use config::Config;
 use pocsag::Generator;
 use transmitter::Transmitter;
 
-pub struct STM32Transmitter {
+pub struct RFM69Transmitter {
     serial: Box<serial::SerialPort>
 }
 
-impl STM32Transmitter  {
-    pub fn new(config: &Config) -> STM32Transmitter {
-        info!("Initializing STM32Pager transmitter...");
+impl RFM69Transmitter  {
+    pub fn new(config: &Config) -> RFM69Transmitter {
+        info!("Initializing RFM69 transmitter...");
 
-        let mut serial = serial::open(&config.stm32pager.port)
+        let mut serial = serial::open(&config.rfm69.port)
             .expect("Unable to open serial port");
 
         serial.configure(&serial::PortSettings {
@@ -23,7 +23,7 @@ impl STM32Transmitter  {
             flow_control: serial::FlowControl::FlowNone
         }).expect("Unable to configure serial port");
 
-        let transmitter = STM32Transmitter {
+        let transmitter = RFM69Transmitter {
             serial: Box::new(serial)
         };
 
@@ -31,7 +31,7 @@ impl STM32Transmitter  {
     }
 }
 
-impl Transmitter for STM32Transmitter {
+impl Transmitter for RFM69Transmitter {
     fn send(&mut self, gen: Generator) {
         for word in gen {
             let bytes = [((word & 0xff000000) >> 24) as u8,

--- a/src/transmitter/stm32pager/mod.rs
+++ b/src/transmitter/stm32pager/mod.rs
@@ -1,3 +1,0 @@
-mod transmitter;
-
-pub use self::transmitter::STM32Transmitter;


### PR DESCRIPTION
Der Name trifft es eher, da nun anstelle des STM32 auch ein Arduino genutzt werden kann. Das verbindende Element ist aber der RFM69.