### PR TITLE
Nodeliste: Tippfehler berichtigt und erweitert

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -12,10 +12,12 @@ fn default_fallback_servers() -> Vec<(String, u16)> {
         ("debian2.dl4ste.ampr.org", 43434),
         ("dl5ml.db0sda.ampr.org", 43434),
         ("db0rta.ampr.org", 43434),
-        ("dapnet.db0vvs.de.ampr.org", 43434),
+        ("dapnet.db0vvs.ampr.org", 43434),
         ("db0wa.ampr.org", 43434),
         ("dapnet.ampr.org", 43434),
         ("on3dhc.db0sda.ampr.org", 43434)
+        ("dapnet.afu.rwth-aachen.de", 43434)
+        ("db0dbn.ig-funk-siebengebirge.de", 43434)
     ]
         .iter()
         .map(|&(ref host, port)| (host.to_string(), port))

--- a/src/config.rs
+++ b/src/config.rs
@@ -15,8 +15,8 @@ fn default_fallback_servers() -> Vec<(String, u16)> {
         ("dapnet.db0vvs.ampr.org", 43434),
         ("db0wa.ampr.org", 43434),
         ("dapnet.ampr.org", 43434),
-        ("on3dhc.db0sda.ampr.org", 43434)
-        ("dapnet.afu.rwth-aachen.de", 43434)
+        ("on3dhc.db0sda.ampr.org", 43434),
+        ("dapnet.afu.rwth-aachen.de", 43434),
         ("db0dbn.ig-funk-siebengebirge.de", 43434)
     ]
         .iter()


### PR DESCRIPTION
Die DNS-Adresse dapnet.db0vvs.DE.ampr.org wird nicht aufgelöst, ohne .DE geht es.
Mit zwei Webadressen gibt es eine Fallback-Möglichkeit für Internetnutzer.