### PR TITLE
Implement hidraw PTT control

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,6 +44,7 @@ matrix:
 
 before_install:
   - sudo dpkg --add-architecture armhf
+  - sed -i 's/^deb http/deb [arch=i386,amd64] http/' /etc/apt/sources.list
   - echo "deb [arch=armel,armhf] http://ports.ubuntu.com/ubuntu-ports trusty main universe restricted multiverse" >> /etc/apt/sources.list
   - echo "deb [arch=armel,armhf] http://ports.ubuntu.com/ubuntu-ports trusty-updates main universe restricted multiverse" >> /etc/apt/sources.list
   - sudo apt-get update

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,7 @@ matrix:
         apt:
           packages:
             - gcc-multilib
+            - libudev-dev
     - env:
         - TARGET=x86_64-unknown-linux-gnu
         - PACKAGE=unipager-x86_64.tar.gz

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: generic
+
 matrix:
   include:
     - env:
@@ -53,6 +54,7 @@ before_install:
   - sudo echo "deb [arch=armel,armhf] http://ports.ubuntu.com/ubuntu-ports trusty main universe restricted multiverse" >> /etc/apt/sources.list
   - sudo echo "deb [arch=armel,armhf] http://ports.ubuntu.com/ubuntu-ports trusty-updates main universe restricted multiverse" >> /etc/apt/sources.list
   - sudo apt-get update
+  - sudo apt-get -y install libudev-dev:armhf
 
 install:
   - export PATH="$PATH:$HOME/.cargo/bin"

--- a/.travis.yml
+++ b/.travis.yml
@@ -54,7 +54,7 @@ before_install:
   - sudo echo "deb [arch=armel,armhf] http://ports.ubuntu.com/ubuntu-ports trusty main universe restricted multiverse" >> /etc/apt/sources.list
   - sudo echo "deb [arch=armel,armhf] http://ports.ubuntu.com/ubuntu-ports trusty-updates main universe restricted multiverse" >> /etc/apt/sources.list
   - sudo apt-get update
-  - sudo apt-get -y install libudev-dev:armhf
+  - sudo apt-get -y install libudev-dev:armhf libudev-dev
   - sudo dpkg -l | grep udev
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ matrix:
             - gcc-arm-linux-gnueabi
             - libc6-armel-cross
             - libc6-dev-armel-cross
+            - libudev-dev
     - env:
         - TARGET=arm-unknown-linux-gnueabihf
         - LINKER=arm-linux-gnueabihf-gcc
@@ -21,6 +22,7 @@ matrix:
             - gcc-arm-linux-gnueabihf
             - libc6-armhf-cross
             - libc6-dev-armhf-cross
+            - libudev-dev
     - env:
         - TARGET=armv7-unknown-linux-gnueabihf
         - LINKER=arm-linux-gnueabihf-gcc

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,6 +44,8 @@ matrix:
 
 before_install:
   - sudo dpkg --add-architecture armhf
+  - echo "deb [arch=armel,armhf] http://ports.ubuntu.com/ubuntu-ports trusty main universe restricted multiverse" >> /etc/apt/sources.list
+  - echo "deb [arch=armel,armhf] http://ports.ubuntu.com/ubuntu-ports trusty-updates main universe restricted multiverse" >> /etc/apt/sources.list
   - sudo apt-get update
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,9 +44,9 @@ matrix:
 
 before_install:
   - sudo dpkg --add-architecture armhf
-  - sed -i 's/^deb http/deb [arch=i386,amd64] http/' /etc/apt/sources.list
-  - echo "deb [arch=armel,armhf] http://ports.ubuntu.com/ubuntu-ports trusty main universe restricted multiverse" >> /etc/apt/sources.list
-  - echo "deb [arch=armel,armhf] http://ports.ubuntu.com/ubuntu-ports trusty-updates main universe restricted multiverse" >> /etc/apt/sources.list
+  - sudo sed -i 's/^deb http/deb [arch=i386,amd64] http/' /etc/apt/sources.list
+  - sudo echo "deb [arch=armel,armhf] http://ports.ubuntu.com/ubuntu-ports trusty main universe restricted multiverse" >> /etc/apt/sources.list
+  - sudo echo "deb [arch=armel,armhf] http://ports.ubuntu.com/ubuntu-ports trusty-updates main universe restricted multiverse" >> /etc/apt/sources.list
   - sudo apt-get update
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ matrix:
     - env:
         - TARGET=arm-unknown-linux-gnueabi
         - LINKER=arm-linux-gnueabi-gcc
+        - PKG_CONFIG_ALLOW_CROSS=1
         - PACKAGE=unipager-arm.tar.gz
       addons:
         apt:
@@ -15,6 +16,7 @@ matrix:
     - env:
         - TARGET=arm-unknown-linux-gnueabihf
         - LINKER=arm-linux-gnueabihf-gcc
+        - PKG_CONFIG_ALLOW_CROSS=1
         - PACKAGE=unipager-rpi2.tar.gz
       addons:
         apt:
@@ -26,12 +28,14 @@ matrix:
     - env:
         - TARGET=armv7-unknown-linux-gnueabihf
         - LINKER=arm-linux-gnueabihf-gcc
+        - PKG_CONFIG_ALLOW_CROSS=1
         - PACKAGE=unipager-rpi3.tar.gz
       addons:
         apt:
           packages: *armhf
     - env:
         - TARGET=i686-unknown-linux-gnu
+        - PKG_CONFIG_ALLOW_CROSS=1
         - PACKAGE=unipager-i686.tar.gz
       addons:
         apt:
@@ -40,6 +44,7 @@ matrix:
             - libudev-dev
     - env:
         - TARGET=x86_64-unknown-linux-gnu
+        - PKG_CONFIG_ALLOW_CROSS=1
         - PACKAGE=unipager-x86_64.tar.gz
 
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,6 +42,10 @@ matrix:
         - TARGET=x86_64-unknown-linux-gnu
         - PACKAGE=unipager-x86_64.tar.gz
 
+before_install:
+  - sudo dpkg --add-architecture armhf
+  - sudo apt-get update
+
 install:
   - export PATH="$PATH:$HOME/.cargo/bin"
   - curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain=nightly

--- a/.travis.yml
+++ b/.travis.yml
@@ -55,6 +55,7 @@ before_install:
   - sudo echo "deb [arch=armel,armhf] http://ports.ubuntu.com/ubuntu-ports trusty-updates main universe restricted multiverse" >> /etc/apt/sources.list
   - sudo apt-get update
   - sudo apt-get -y install libudev-dev:armhf
+  - sudo dpkg -l | grep udev
 
 install:
   - export PATH="$PATH:$HOME/.cargo/bin"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -140,7 +140,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 0.4.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "synstructure 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -408,7 +408,7 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.1.42"
+version = "0.1.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -438,7 +438,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 0.4.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.22 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -501,7 +501,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "syn"
-version = "0.15.21"
+version = "0.15.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 0.4.24 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -516,7 +516,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 0.4.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -542,7 +542,7 @@ version = "0.1.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.44 (registry+https://github.com/rust-lang/crates.io-index)",
- "redox_syscall 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_syscall 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -579,7 +579,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "unipager"
-version = "1.0.3"
+version = "1.0.4"
 dependencies = [
  "hidapi 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -733,7 +733,7 @@ dependencies = [
 "checksum quote 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)" = "53fa22a1994bd0f9372d7a816207d8a2677ad0325b073f5c5332760f0fb62b5c"
 "checksum rand 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)" = "15a732abf9d20f0ad8eeb6f909bf6868722d9a06e1e50802b6a70351f40b4eb1"
 "checksum rand 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "8356f47b32624fef5b3301c1be97e5944ecdd595409cc5da11d05f211db6cfbd"
-"checksum redox_syscall 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "cf8fb82a4d1c9b28f1c26c574a5b541f5ffb4315f6c9a791fa47b6a04438fe93"
+"checksum redox_syscall 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)" = "679da7508e9a6390aeaf7fbd02a800fdc64b73fe2204dd2c8ae66d22d9d5ad5d"
 "checksum rustc-demangle 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "bcfe5b13211b4d78e5c2cadfebd7769197d95c639c35a50057eb4c05de811395"
 "checksum rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)" = "dcf128d1287d2ea9d80910b5f1120d0b8eede3fbf1abe91c40d39ea7d51e6fda"
 "checksum ryu 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "eb9e9b8cde282a9fe6a42dd4681319bfb63f121b8a8ee9439c6f4107e58a46f7"
@@ -746,7 +746,7 @@ dependencies = [
 "checksum serial-windows 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "15c6d3b776267a75d31bbdfd5d36c0ca051251caafc285827052bc53bcdc8162"
 "checksum sha1 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2579985fda508104f7587689507983eadd6a6e84dd35d6d115361f530916fa0d"
 "checksum slab 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "5f9776d6b986f77b35c6cf846c11ad986ff128fe0b2b63a3628e3755e8d3102d"
-"checksum syn 0.15.21 (registry+https://github.com/rust-lang/crates.io-index)" = "816b7af21405b011a23554ea2dc3f6576dc86ca557047c34098c1d741f10f823"
+"checksum syn 0.15.22 (registry+https://github.com/rust-lang/crates.io-index)" = "ae8b29eb5210bc5cf63ed6149cbf9adfc82ac0be023d8735c176ee74a2db4da7"
 "checksum synstructure 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "73687139bf99285483c96ac0add482c3776528beac1d97d444f6e91f203a2015"
 "checksum sysfs_gpio 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3d68f2cae3c7d39f54ce8a858cc31ffb01974744ee65e5b4999b6037cd691e3f"
 "checksum termios 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d5d9cf598a6d7ce700a4e6a9199da127e6819a61e64b68609683cc9a01b5683a"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,6 +4,27 @@ version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "backtrace"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "backtrace-sys 0.1.24 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.44 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-demangle 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "backtrace-sys"
+version = "0.1.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cc 1.0.25 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.44 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -21,6 +42,11 @@ dependencies = [
  "byteorder 1.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "cc"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "cfg-if"
@@ -99,6 +125,26 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "failure"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "backtrace 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure_derive 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "failure_derive"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 0.4.24 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "synstructure 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "fuchsia-zircon"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -116,6 +162,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "gcc"
 version = "0.3.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "hidapi"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cc 1.0.25 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure_derive 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.44 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pkg-config 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "httparse"
@@ -300,6 +358,11 @@ version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "pkg-config"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "proc-macro2"
 version = "0.4.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -346,6 +409,11 @@ dependencies = [
 [[package]]
 name = "redox_syscall"
 version = "0.1.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "rustc-demangle"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -442,6 +510,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "synstructure"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 0.4.24 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "sysfs_gpio"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -502,6 +581,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "unipager"
 version = "1.0.3"
 dependencies = [
+ "hidapi 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "raspi 0.1.0",
@@ -604,9 +684,12 @@ dependencies = [
 
 [metadata]
 "checksum ascii 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3ae7d751998c189c1d4468cf0a39bb2eae052a9c58d50ebb3b9591ee3813ad50"
+"checksum backtrace 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "89a47830402e9981c5c41223151efcced65a0510c13097c769cede7efb34782a"
+"checksum backtrace-sys 0.1.24 (registry+https://github.com/rust-lang/crates.io-index)" = "c66d56ac8dabd07f6aacdaf633f4b8262f5b3601a810a0dcddffd5c22c69daa0"
 "checksum bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "228047a76f468627ca71776ecdebd732a3423081fcf5125585bcd7c49886ce12"
 "checksum byteorder 1.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "94f88df23a25417badc922ab0f5716cc1330e87f71ddd9203b3a3ccd9cedf75d"
 "checksum bytes 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)" = "40ade3d27603c2cb345eb0912aec461a6dec7e06a4ae48589904e808335c7afa"
+"checksum cc 1.0.25 (registry+https://github.com/rust-lang/crates.io-index)" = "f159dfd43363c4d08055a07703eb7a3406b0dac4d0584d96965a3262db3c9d16"
 "checksum cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "082bb9b28e00d3c9d39cc03e64ce4cea0f1bb9b3fde493f0cbc008472d22bdf4"
 "checksum chrono 0.2.25 (registry+https://github.com/rust-lang/crates.io-index)" = "9213f7cd7c27e95c2b57c49f0e69b1ea65b27138da84a170133fd21b07659c00"
 "checksum chunked_transfer 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "498d20a7aaf62625b9bf26e637cf7736417cde1d0c99f1d04d1170229a85cf87"
@@ -617,9 +700,12 @@ dependencies = [
 "checksum encoding-index-singlebyte 1.20141219.5 (registry+https://github.com/rust-lang/crates.io-index)" = "3351d5acffb224af9ca265f435b859c7c01537c0849754d3db3fdf2bfe2ae84a"
 "checksum encoding-index-tradchinese 1.20141219.5 (registry+https://github.com/rust-lang/crates.io-index)" = "fd0e20d5688ce3cab59eb3ef3a2083a5c77bf496cb798dc6fcdb75f323890c18"
 "checksum encoding_index_tests 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "a246d82be1c9d791c5dfde9a2bd045fc3cbba3fa2b11ad558f27d01712f00569"
+"checksum failure 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "6dd377bcc1b1b7ce911967e3ec24fa19c3224394ec05b54aa7b083d498341ac7"
+"checksum failure_derive 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "64c2d913fe8ed3b6c6518eedf4538255b989945c14c2a7d5cbff62a5e2120596"
 "checksum fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
 "checksum fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
 "checksum gcc 0.3.55 (registry+https://github.com/rust-lang/crates.io-index)" = "8f5f3913fa0bfe7ee1fd8248b6b9f42a5af4b9d65ec2dd2c3c26132b950ecfc2"
+"checksum hidapi 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2511971f82b321b33b8a7695442f59129e2d9bc302302cbcdb962eb739a78cff"
 "checksum httparse 1.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "e8734b0cfd3bc3e101ec59100e101c2eecd19282202e87808b3037b442777a83"
 "checksum idna 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "38f09e0f0b1fb55fdee1f17470ad800da77af5186a1a76c026b679358b7e844e"
 "checksum ioctl-rs 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "f7970510895cee30b3e9128319f2cefd4bde883a39f38baa279567ba3a7eb97d"
@@ -642,11 +728,13 @@ dependencies = [
 "checksum num-iter 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)" = "af3fdbbc3291a5464dc57b03860ec37ca6bf915ed6ee385e7c6c052c422b2124"
 "checksum num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "0b3a5d7cc97d6d30d8b9bc8fa19bf45349ffe46241e8816f50f62f6d6aaabee1"
 "checksum percent-encoding 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "31010dd2e1ac33d5b46a5b413495239882813e0369f8ed8a5e266f173602f831"
+"checksum pkg-config 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)" = "676e8eb2b1b4c9043511a9b7bea0915320d7e502b0a079fb03f9635a5252b18c"
 "checksum proc-macro2 0.4.24 (registry+https://github.com/rust-lang/crates.io-index)" = "77619697826f31a02ae974457af0b29b723e5619e113e9397b8b82c6bd253f09"
 "checksum quote 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)" = "53fa22a1994bd0f9372d7a816207d8a2677ad0325b073f5c5332760f0fb62b5c"
 "checksum rand 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)" = "15a732abf9d20f0ad8eeb6f909bf6868722d9a06e1e50802b6a70351f40b4eb1"
 "checksum rand 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "8356f47b32624fef5b3301c1be97e5944ecdd595409cc5da11d05f211db6cfbd"
 "checksum redox_syscall 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "cf8fb82a4d1c9b28f1c26c574a5b541f5ffb4315f6c9a791fa47b6a04438fe93"
+"checksum rustc-demangle 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "bcfe5b13211b4d78e5c2cadfebd7769197d95c639c35a50057eb4c05de811395"
 "checksum rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)" = "dcf128d1287d2ea9d80910b5f1120d0b8eede3fbf1abe91c40d39ea7d51e6fda"
 "checksum ryu 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "eb9e9b8cde282a9fe6a42dd4681319bfb63f121b8a8ee9439c6f4107e58a46f7"
 "checksum serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)" = "15c141fc7027dd265a47c090bf864cf62b42c4d228bbcf4e51a0c9e2b0d3f7ef"
@@ -659,6 +747,7 @@ dependencies = [
 "checksum sha1 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2579985fda508104f7587689507983eadd6a6e84dd35d6d115361f530916fa0d"
 "checksum slab 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "5f9776d6b986f77b35c6cf846c11ad986ff128fe0b2b63a3628e3755e8d3102d"
 "checksum syn 0.15.21 (registry+https://github.com/rust-lang/crates.io-index)" = "816b7af21405b011a23554ea2dc3f6576dc86ca557047c34098c1d741f10f823"
+"checksum synstructure 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "73687139bf99285483c96ac0add482c3776528beac1d97d444f6e91f203a2015"
 "checksum sysfs_gpio 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3d68f2cae3c7d39f54ce8a858cc31ffb01974744ee65e5b4999b6037cd691e3f"
 "checksum termios 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d5d9cf598a6d7ce700a4e6a9199da127e6819a61e64b68609683cc9a01b5683a"
 "checksum time 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)" = "d825be0eb33fda1a7e68012d51e9c7f451dc1a69391e7fdc197060bb8c56667b"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -579,7 +579,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "unipager"
-version = "1.0.4"
+version = "1.0.3"
 dependencies = [
  "hidapi 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ serde = "^1.0"
 serde_derive = "^1.0"
 serde_json = "^1.0"
 lazy_static = "^1.0"
+hidapi = "^0.5.0"
 
 [dependencies.raspi]
 path = "lib/raspi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,11 @@ serde = "^1.0"
 serde_derive = "^1.0"
 serde_json = "^1.0"
 lazy_static = "^1.0"
-hidapi = "^0.5.0"
 
 [dependencies.raspi]
 path = "lib/raspi"
+
+[dependencies.hidapi]
+version = "0.5.0"
+default-features = false
+features = ["linux-static-hidraw"] # or linux-shared-hidraw

--- a/src/config.rs
+++ b/src/config.rs
@@ -102,7 +102,8 @@ impl Default for AudioConfig {
 pub enum PttMethod {
     Gpio,
     SerialDtr,
-    SerialRts
+    SerialRts,
+    HidRaw
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
@@ -111,7 +112,8 @@ pub struct PttConfig {
     pub method: PttMethod,
     pub inverted: bool,
     pub gpio_pin: usize,
-    pub serial_port: String
+    pub serial_port: String,
+    pub hidraw_device: String
 }
 
 impl Default for PttConfig {
@@ -120,7 +122,8 @@ impl Default for PttConfig {
             method: PttMethod::Gpio,
             inverted: false,
             gpio_pin: 0,
-            serial_port: String::from("/dev/ttyS0")
+            serial_port: String::from("/dev/ttyS0"),
+            hidraw_device: String::from("/dev/hidraw0")
         }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -113,7 +113,8 @@ pub struct PttConfig {
     pub inverted: bool,
     pub gpio_pin: usize,
     pub serial_port: String,
-    pub hidraw_device: String
+    pub hidraw_device: String,
+    pub hidraw_gpio_pin: usize,
 }
 
 impl Default for PttConfig {
@@ -123,7 +124,8 @@ impl Default for PttConfig {
             inverted: false,
             gpio_pin: 0,
             serial_port: String::from("/dev/ttyS0"),
-            hidraw_device: String::from("/dev/hidraw0")
+            hidraw_device: String::from("/dev/hidraw0"),
+            hidraw_gpio_pin: 3,
         }
     }
 }

--- a/src/frontend/assets/index.html
+++ b/src/frontend/assets/index.html
@@ -233,7 +233,7 @@
                   <input type="text" id="ptt-hidraw-device"
                     v-model="config.ptt.hidraw_device">
                 </div>
-                <div class="form-group" v-if="config.ptt.method != 'HidRaw'">
+                <div class="form-group">
                   <label for="ptt-inverted">Inverted</label>
                   <input type="checkbox" id="ptt-inverted"
                     v-model="config.ptt.inverted">

--- a/src/frontend/assets/index.html
+++ b/src/frontend/assets/index.html
@@ -207,6 +207,7 @@
                     <option value="Gpio">GPIO</option>
                     <option value="SerialDtr">Serial (DTR)</option>
                     <option value="SerialRts">Serial (RTS)</option>
+                    <option value="HidRaw">HIDraw</option>
                   </select>
                 </div>
               </div>
@@ -227,7 +228,12 @@
                   <input type="text" id="ptt-serial-port"
                     v-model="config.ptt.serial_port">
                 </div>
-                <div class="form-group">
+                <div class="form-group" v-if="config.ptt.method == 'HidRaw'">
+                  <label for="ptt-hidraw-device">Hidraw Device</label>
+                  <input type="text" id="ptt-hidraw-device"
+                    v-model="config.ptt.hidraw_device">
+                </div>
+                <div class="form-group" v-if="config.ptt.method != 'HidRaw'">
                   <label for="ptt-inverted">Inverted</label>
                   <input type="checkbox" id="ptt-inverted"
                     v-model="config.ptt.inverted">

--- a/src/frontend/assets/index.html
+++ b/src/frontend/assets/index.html
@@ -233,6 +233,15 @@
                   <input type="text" id="ptt-hidraw-device"
                     v-model="config.ptt.hidraw_device">
                 </div>
+                <div class="form-group" v-if="config.ptt.method == 'HidRaw'">
+                  <label for="ptt-hidraw-gpio-pin">
+                    GPIO Pin
+                  </label>
+                    <span class="help" title="Default is GPIO3 (pin 13)">?</span>
+                  <input type="number" id="ptt-hidraw-gpio-pin"
+                    v-model.number="config.ptt.hidraw_gpio_pin"
+                    step="1" min="1" max="4" class="u8-number">
+                </div>
                 <div class="form-group">
                   <label for="ptt-inverted">Inverted</label>
                   <input type="checkbox" id="ptt-inverted"

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,8 +33,6 @@ use connection::Connection;
 use frontend::{Request, Response};
 use pocsag::Scheduler;
 
-use hidapi::HidApi;
-
 fn print_version() {
     println!("UniPager {}", env!("CARGO_PKG_VERSION"));
     println!("Copyright (c) 2017 RWTH Amateurfunkgruppe\n");

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,7 @@ extern crate raspi;
 extern crate ws;
 extern crate tiny_http;
 extern crate serde;
+extern crate hidapi;
 #[macro_use]
 extern crate serde_derive;
 #[macro_use]
@@ -31,6 +32,8 @@ use config::Config;
 use connection::Connection;
 use frontend::{Request, Response};
 use pocsag::Scheduler;
+
+use hidapi::HidApi;
 
 fn print_version() {
     println!("UniPager {}", env!("CARGO_PKG_VERSION"));

--- a/src/transmitter/ptt.rs
+++ b/src/transmitter/ptt.rs
@@ -1,6 +1,7 @@
 use config::{PttConfig, PttMethod};
 use raspi::{Direction, Gpio, Model, Pin};
 use serial;
+use std::ffi::CString;
 
 pub enum Ptt {
     Gpio { pin: Box<Pin>, inverted: bool },
@@ -56,8 +57,8 @@ impl Ptt {
                 let api = hidapi::HidApi::new().expect(
                     "Unable to initialize HID API"
                 );
-                let (vid, pid) = (0x0d8c, 0x013c);
-                 let device = api.open(vid, pid).expect(
+                let path = CString::new(&*config.hidraw_device).unwrap();
+                let device = api.open_path(&path).expect(
                     "Unable to open HIDraw device"
                 );
 

--- a/src/transmitter/ptt.rs
+++ b/src/transmitter/ptt.rs
@@ -71,6 +71,19 @@ impl Ptt {
                 let cm108device = api.open_path(&path).expect(
                     "Unable to open HIDraw device"
                 );
+                let mut string = "Device data: manufacturer \"".to_string();
+                let manufacturer = cm108device.get_manufacturer_string().unwrap();
+                match manufacturer {
+                    Some(x) => string.push_str(&x.trim()),
+                    None    => string.push_str("n/a"),
+                }
+                string.push_str("\", product \"");
+                let product = cm108device.get_product_string().unwrap();
+                match product {
+                    Some(x) => string.push_str(&x.trim()),
+                    None    => string.push_str("n/a"),
+                }
+                info!("{}\"", string);
 
                 Ptt::HidRaw {
                     device: Box::new(cm108device),

--- a/src/transmitter/ptt.rs
+++ b/src/transmitter/ptt.rs
@@ -59,26 +59,21 @@ impl Ptt {
                 );
                 info!("Using device {}", &*config.hidraw_device);
                 let path = CString::new(&*config.hidraw_device).unwrap();
-                let device = api.open_path(&path).expect(
+                for device in api.devices() {
+                    if device.path == path {
+                        if device.vendor_id == 0x0d8c && (device.product_id == 0x013c || device.product_id == 0x000c) {
+                            info!("Found CM108 device {:#06x}/{:#06x}", device.vendor_id, device.product_id);
+                        } else {
+                            error!("Unsupported device {:#06x}/{:#06x}!", device.vendor_id, device.product_id);
+                        }
+                    }
+                }
+                let cm108device = api.open_path(&path).expect(
                     "Unable to open HIDraw device"
                 );
 
-                let mut string = "Found HIDraw device, manufacturer \"".to_string();
-                let manufacturer = device.get_manufacturer_string().unwrap();
-                match manufacturer {
-                    Some(x) => string.push_str(&x.trim()),
-                    None    => string.push_str("n/a"),
-                }
-                string.push_str("\", product \"");
-                let product = device.get_product_string().unwrap();
-                match product {
-                    Some(x) => string.push_str(&x.trim()),
-                    None    => string.push_str("n/a"),
-                }
-                info!("{}\"", string);
-
                 Ptt::HidRaw {
-                    device: Box::new(device),
+                    device: Box::new(cm108device),
                     inverted: config.inverted
                 }
             }

--- a/src/transmitter/ptt.rs
+++ b/src/transmitter/ptt.rs
@@ -57,6 +57,7 @@ impl Ptt {
                 let api = hidapi::HidApi::new().expect(
                     "Unable to initialize HID API"
                 );
+                info!("Using device {}", &*config.hidraw_device);
                 let path = CString::new(&*config.hidraw_device).unwrap();
                 let device = api.open_path(&path).expect(
                     "Unable to open HIDraw device"

--- a/src/transmitter/ptt.rs
+++ b/src/transmitter/ptt.rs
@@ -11,6 +11,8 @@ pub enum Ptt {
     SerialRts {
         port: Box<serial::SerialPort>,
         inverted: bool
+    },
+    HidRaw {
     }
 }
 
@@ -47,6 +49,11 @@ impl Ptt {
                     inverted: config.inverted
                 }
             }
+
+            PttMethod::HidRaw => {
+                Ptt::HidRaw {
+                }
+            }
         }
     }
 
@@ -70,6 +77,9 @@ impl Ptt {
                 port.set_rts(status != inverted).expect(
                     "Error setting RTS pin"
                 );
+            }
+            Ptt::HidRaw {
+            } => {
             }
         }
     }


### PR DESCRIPTION
This code implements a PTT switch controlable via HID API. It supports CM108 chips with 4 GPIOs. The used GPIO pin is configurable from the web interface. This is useful for configurations with a single soundcard board (e.g. DingleBop developed by DB9MAT, DF2ET and DG1TAL aka. GM3x0APRS).