### PR TITLE
Bugfix/#92 enable variable baudrate for audio transmitter

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -1,8 +1,9 @@
-use serde_json;
 use std::fmt;
 use std::fs::File;
 use std::io::{Read, Write};
 use std::sync::RwLock;
+
+use serde_json;
 
 const CONFIG_FILE: &'static str = "config.json";
 
@@ -29,7 +30,7 @@ pub struct C9000Config {
     pub baudrate: u32,
     pub dummy_enabled: bool,
     pub dummy_port: String,
-    pub dummy_pa_output_level: u8
+    pub dummy_pa_output_level: u8,
 }
 
 impl Default for C9000Config {
@@ -38,7 +39,7 @@ impl Default for C9000Config {
             baudrate: 38400,
             dummy_enabled: false,
             dummy_port: String::from("/dev/ttyUSB0"),
-            dummy_pa_output_level: 0
+            dummy_pa_output_level: 0,
         }
     }
 }
@@ -58,7 +59,7 @@ impl Default for RaspagerConfig {
             freq: 439987500,
             freq_corr: 0,
             pa_output_level: 63,
-            mod_deviation: default_mod_deviation()
+            mod_deviation: default_mod_deviation(),
         }
     }
 }
@@ -83,7 +84,8 @@ pub struct AudioConfig {
     pub level: u8,
     pub inverted: bool,
     #[serde(default)]
-    pub tx_delay: usize
+    pub tx_delay: usize,
+    pub baudrate: usize,
 }
 
 impl Default for AudioConfig {
@@ -92,7 +94,8 @@ impl Default for AudioConfig {
             device: String::from("default"),
             level: 127,
             inverted: false,
-            tx_delay: 0
+            tx_delay: 0,
+            baudrate: 1200,
         }
     }
 }
@@ -103,7 +106,7 @@ pub enum PttMethod {
     SerialDtr,
     SerialRts,
     #[cfg(hid_ptt)]
-    HidRaw
+    HidRaw,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
@@ -141,7 +144,7 @@ pub struct MasterConfig {
     pub port: u16,
     pub call: String,
     pub auth: String,
-    pub fallback: Vec<(String, u16)>
+    pub fallback: Vec<(String, u16)>,
 }
 
 impl Default for MasterConfig {
@@ -151,7 +154,7 @@ impl Default for MasterConfig {
             port: 80,
             call: String::from(""),
             auth: String::from(""),
-            fallback: default_fallback_servers()
+            fallback: default_fallback_servers(),
         }
     }
 }
@@ -163,7 +166,7 @@ pub enum Transmitter {
     C9000,
     Raspager,
     Raspager2,
-    RFM69
+    RFM69,
 }
 
 impl Default for Transmitter {
@@ -195,7 +198,7 @@ pub struct Config {
     pub raspager: RaspagerConfig,
     pub c9000: C9000Config,
     pub audio: AudioConfig,
-    pub rfm69: RFM69Config
+    pub rfm69: RFM69Config,
 }
 
 pub fn get() -> Config {

--- a/src/frontend/assets/index.html
+++ b/src/frontend/assets/index.html
@@ -191,6 +191,14 @@
                     step="1" min="0" max="100"
                     class="u8-number">
                 </div>
+                <div class="form-group">
+                  <label for="audio-baudrate">Baudrate</label>
+                  <select id="audio-baudrate" v-model.number="config.audio.baudrate">
+                    <option>512</option>
+                    <option>1200</option>
+                    <option>2400</option>
+                  </select>
+                </div>
               </div>
             </div>
           </div>
@@ -269,8 +277,11 @@
               </div>
               <div class="form-row">
                 <div class="form-group">
-                  <label for="message-speed">Baudrate</label>
-                  <select id="message-speed" v-model.number="message.message.speed">
+                  <label for="message-speed">Baudrate
+                    <span class="help"
+                          title="Only 1200 is supported. For Audio transmitter it can be overwritten in the transmitter.">?</span>
+                  </label>
+                  <select id="message-speed" v-model.number="message.message.speed" disabled>
                     <option>512</option>
                     <option>1200</option>
                     <option>2400</option>

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -1,3 +1,4 @@
+use chrono::Utc;
 use log::{self, Level, LevelFilter, Log, Metadata, Record};
 
 use crate::event::{Event, EventHandler};
@@ -20,7 +21,14 @@ impl Log for Logger {
                 Level::Info => "\x1B[32m",
                 _ => "",
             };
-            println!("{}{}\x1B[39m - {}", color, record.level(), record.args());
+
+            let time = Utc::now();
+            println!(
+                "{} {}{}\x1B[39m - {}",
+                time.format("%H:%M:%S%.f"),
+                color,
+                record.level(),
+                record.args());
             let event = Event::Log(record.level() as u8, record.args().to_string());
             self.event_handler.publish(event);
         }

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -1,5 +1,5 @@
-//use frontend::{Responder, Response};
-use log::{self, Log, Level, LevelFilter, Metadata, Record};
+use log::{self, Level, LevelFilter, Log, Metadata, Record};
+
 use crate::event::{Event, EventHandler};
 
 struct Logger {
@@ -30,8 +30,7 @@ impl Log for Logger {
 }
 
 pub fn init(event_handler: EventHandler) {
-    log::set_boxed_logger(Box::new(
-        Logger { event_handler: event_handler }
-    )).expect("Unable to setup logger");
+    log::set_boxed_logger(Box::new(Logger { event_handler }))
+        .expect("Unable to setup logger");
     log::set_max_level(LevelFilter::Trace);
 }

--- a/src/pocsag/generator.rs
+++ b/src/pocsag/generator.rs
@@ -86,7 +86,7 @@ impl<'a> Iterator for Generator<'a> {
     type Item = u32;
 
     fn next(&mut self) -> Option<u32> {
-        debug!("({}, {:?})", self.codewords, self.state);
+        trace!("Next generated codeword: ({}, {:?})", self.codewords, self.state);
         self.count += 1;
 
         match (self.codewords, self.state)

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -18,7 +18,7 @@ struct Scheduler {
     budget: usize,
     test: bool,
     stop: bool,
-    restart: bool
+    restart: bool,
 }
 
 pub fn start(config: Config, event_handler: EventHandler) {
@@ -41,7 +41,7 @@ impl Scheduler {
             budget: 0,
             test: false,
             stop: false,
-            restart: true
+            restart: true,
         }
     }
 
@@ -51,16 +51,14 @@ impl Scheduler {
             if self.test {
                 self.test(transmitter);
                 self.test = false;
-            }
-            else {
+            } else {
                 self.run(transmitter);
             }
 
             if !self.restart {
                 info!("Shutting down the scheduler...");
                 return;
-            }
-            else {
+            } else {
                 info!("Restarting the scheduler...");
                 self.stop = false;
             }
@@ -77,7 +75,7 @@ impl Scheduler {
                 if self.stop { return; }
             }
 
-            info!("Queue not empty, waiting for next Timeslot.");
+            info!("Queue not empty, waiting for next Timeslot. {} messages waiting.", self.queue.len());
             self.wait_for_next_timeslot();
             if self.stop { return; }
 
@@ -164,7 +162,6 @@ impl Scheduler {
             }
             _ => {}
         }
-
     }
 
     fn recv_event(&mut self) -> Option<Event> {

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -34,8 +34,8 @@ pub fn start(config: Config, event_handler: EventHandler) {
 impl Scheduler {
     pub fn new(config: Config, rx: Receiver<Event>) -> Scheduler {
         Scheduler {
-            config: config,
-            rx: rx,
+            config,
+            rx,
             slots: TimeSlots::new(),
             queue: Queue::new(),
             budget: 0,

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -75,7 +75,7 @@ impl Scheduler {
                 if self.stop { return; }
             }
 
-            info!("Queue not empty, waiting for next Timeslot. {} messages waiting.", self.queue.len());
+            info!("Queue not empty, waiting for next Timeslot. {} message(s) waiting.", self.queue.len());
             self.wait_for_next_timeslot();
             if self.stop { return; }
 

--- a/src/transmitter/audio/transmitter.rs
+++ b/src/transmitter/audio/transmitter.rs
@@ -108,7 +108,7 @@ impl Transmitter for AudioTransmitter {
 
 fn create_bit_sample(sample_size: usize, constant_value: u8) -> Vec<u8> {
     let mut bit_sample: Vec<u8> = Vec::with_capacity(sample_size);
-    for s in 0..sample_size {
+    for _s in 0..sample_size {
         bit_sample.push(constant_value);
     }
 

--- a/src/transmitter/audio/transmitter.rs
+++ b/src/transmitter/audio/transmitter.rs
@@ -7,21 +7,20 @@ use crate::config::Config;
 use crate::transmitter::Ptt;
 use crate::transmitter::Transmitter;
 
-const BAUD_RATE: usize = 1200;
 const SAMPLE_RATE: usize = 48000;
-const SAMPLES_PER_BIT: usize = SAMPLE_RATE / BAUD_RATE;
 
 pub struct AudioTransmitter {
     device: String,
     ptt: Ptt,
     inverted: bool,
     level: u8,
-    tx_delay: usize
+    tx_delay: usize,
+    samples_per_bit: usize,
 }
 
 impl AudioTransmitter {
     pub fn new(config: &Config) -> AudioTransmitter {
-        info!("Initializing audio transmitter...");
+        info!("Initializing audio transmitter with baudrate '{}'...", config.audio.baudrate);
 
         let device = match &*config.audio.device {
             "" => String::from("default"),
@@ -33,7 +32,8 @@ impl AudioTransmitter {
             ptt: Ptt::from_config(&config.ptt),
             inverted: config.audio.inverted,
             level: config.audio.level,
-            tx_delay: config.audio.tx_delay
+            tx_delay: config.audio.tx_delay,
+            samples_per_bit: SAMPLE_RATE / config.audio.baudrate,
         };
 
         if transmitter.level > 127 {
@@ -47,26 +47,36 @@ impl AudioTransmitter {
 }
 
 impl Transmitter for AudioTransmitter {
-    fn send(&mut self, gen: &mut dyn Iterator<Item = u32>) {
+    fn send(&mut self, gen: &mut dyn Iterator<Item=u32>) {
+        trace!("Activating PTT to start transmission.");
         self.ptt.set(true);
 
+        trace!("Waiting for {}ms before audio transmission starts.", self.tx_delay);
         sleep(Duration::from_millis(self.tx_delay as u64));
 
         let mut buffer: Vec<u8> = Vec::with_capacity(SAMPLE_RATE);
         let low_level = 127 - self.level;
         let high_level = 128 + self.level;
+        trace!(
+            "Sending with low_level='{}' and high_level='{}' based on configured level='{}'.",
+            low_level,
+            high_level,
+            self.level);
 
+        let low_bit_sample = create_bit_sample(self.samples_per_bit, low_level);
+        let high_bit_sample = create_bit_sample(self.samples_per_bit, high_level);
         for word in gen {
             for i in 0..32 {
                 let bit = (word & (1 << (31 - i))) != 0;
                 if (!self.inverted && bit) || (self.inverted && !bit) {
-                    buffer.extend_from_slice(&[low_level; SAMPLES_PER_BIT]);
+                    buffer.extend(&low_bit_sample);
                 } else {
-                    buffer.extend_from_slice(&[high_level; SAMPLES_PER_BIT]);
+                    buffer.extend(&high_bit_sample);
                 }
             }
         }
 
+        trace!("Spawning `aplay` child process to start audio transmission.");
         let child = Command::new("aplay")
             .stdin(Stdio::piped())
             .args(&["-t", "raw", "-N", "-f", "U8", "-c", "1"])
@@ -87,11 +97,20 @@ impl Transmitter for AudioTransmitter {
             }
 
             child.wait().ok();
-        }
-        else {
+        } else {
             error!("Failed to start aplay");
         }
 
+        trace!("Deactivating PTT to end transmission.");
         self.ptt.set(false);
     }
+}
+
+fn create_bit_sample(sample_size: usize, constant_value: u8) -> Vec<u8> {
+    let mut bit_sample: Vec<u8> = Vec::with_capacity(sample_size);
+    for s in 0..sample_size {
+        bit_sample.push(constant_value);
+    }
+
+    return bit_sample;
 }

--- a/src/transmitter/ptt.rs
+++ b/src/transmitter/ptt.rs
@@ -26,7 +26,8 @@ impl Ptt {
         match config.method {
             PttMethod::Gpio => {
                 info!("Detected {}", Model::get());
-                let gpio = Gpio::new().expect("Failed to map GPIO");
+                let gpio = Gpio::new()
+                    .expect("Failed to map GPIO. Do you have sufficient permissions to access GPIO pins?");
 
                 Ptt::Gpio {
                     pin: gpio.pin(config.gpio_pin, Direction::Output),
@@ -34,9 +35,8 @@ impl Ptt {
                 }
             }
             PttMethod::SerialDtr => {
-                let port = serial::open(&*config.serial_port).expect(
-                    "Unable to open serial port"
-                );
+                let port = serial::open(&*config.serial_port)
+                    .expect("Unable to open serial port");
 
                 Ptt::SerialDtr {
                     port: Box::new(port),
@@ -45,9 +45,8 @@ impl Ptt {
             }
 
             PttMethod::SerialRts => {
-                let port = serial::open(&*config.serial_port).expect(
-                    "Unable to open serial port"
-                );
+                let port = serial::open(&*config.serial_port)
+                    .expect("Unable to open serial port");
 
                 Ptt::SerialRts {
                     port: Box::new(port),
@@ -57,23 +56,23 @@ impl Ptt {
 
             #[cfg(hid_ptt)]
             PttMethod::HidRaw => {
-                let api = hidapi::HidApi::new().expect(
-                    "Unable to initialize HID API"
-                );
+                let api = hidapi::HidApi::new()
+                    .expect("Unable to initialize HID API");
                 info!("Using device {}", &*config.hidraw_device);
                 let path = CString::new(&*config.hidraw_device).unwrap();
                 for device in api.devices() {
                     if device.path == path {
-                        if device.vendor_id == 0x0d8c && (device.product_id == 0x013c || device.product_id == 0x000c) {
+                        if device.vendor_id == 0x0d8c
+                            && (device.product_id == 0x013c || device.product_id == 0x000c) {
                             info!("Found CM108 device {:#06x}/{:#06x}", device.vendor_id, device.product_id);
                         } else {
                             error!("Unsupported device {:#06x}/{:#06x}!", device.vendor_id, device.product_id);
                         }
                     }
                 }
-                let cm108device = api.open_path(&path).expect(
-                    "Unable to open HIDraw device"
-                );
+
+                let cm108device = api.open_path(&path)
+                    .expect("Unable to open HIDraw device");
                 let mut string = "Device data: manufacturer \"".to_string();
                 let manufacturer = cm108device.get_manufacturer_string().unwrap();
                 match manufacturer {


### PR DESCRIPTION
* Baudrate selection on message sending is greyed-out, since it is dead code
* Baudrate configuration is added to transmitter of type "Audio" to enable variable baudrate for this type of transmitter