### PR TITLE
typo update: message homepage standalone mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ password
 
 # IntelliJ Project Files
 .idea/
+
+# Apple files
+.DS_Store

--- a/src/frontend/assets/index.html
+++ b/src/frontend/assets/index.html
@@ -61,7 +61,7 @@
               </div>
               <div v-if="config.master.standalone_mode === true">
                 Unipager is configured in 'standalone' mode. No server connection is attempted.
-                To change the configuration edit the config.js file and restart the service.
+                To change the configuration edit the config.json file and restart the service.
               </div>
             </div>
           </div>


### PR DESCRIPTION
In the standalone message on the homepage a direction to config.js was made instead of config.json. Corrected this typo.